### PR TITLE
# 3 [FEAT]: 멤버별 리스트 조회

### DIFF
--- a/src/main/java/org/mse/s3_storage/com/controller/PhotoController.java
+++ b/src/main/java/org/mse/s3_storage/com/controller/PhotoController.java
@@ -66,4 +66,12 @@ public class PhotoController {
     public List<String> list() {
         return s3Service.listFolders();
     }
+
+
+    // 특정 멤버의 파일 목록 반환
+    @GetMapping("/{memberId}/list")
+    public ResponseEntity<List<String>> listFiles(@PathVariable Long memberId) {
+        List<String> files = s3Service.listFiles(memberId);
+        return ResponseEntity.ok().body(files);
+    }
 }

--- a/src/main/java/org/mse/s3_storage/com/service/AmazonS3Service.java
+++ b/src/main/java/org/mse/s3_storage/com/service/AmazonS3Service.java
@@ -138,5 +138,29 @@ public class AmazonS3Service {
     }
 
 
+    public List<String> listFiles(Long memberId) {
+        List<String> files = new ArrayList<>();
+        final String directory = memberId.toString() + "/";
+
+        // 객체들을 나열하는 요청 생성
+        ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucket).withPrefix(directory);
+
+        // 객체들을 나열하고 파일들을 추출하여 리스트에 추가
+        ListObjectsV2Result result;
+        do {
+            result = amazonS3Client.listObjectsV2(request);
+            for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+                // 폴더 이름 자체는 포함하지 않도록 필터링
+                if (!objectSummary.getKey().equals(directory)) {
+                    files.add(objectSummary.getKey().substring(directory.length()));
+                }
+            }
+            request.setContinuationToken(result.getNextContinuationToken());
+        } while (result.isTruncated());
+
+        return files;
+    }
+
+
 }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #3    

## Key Changes 🔑
"{memberId}/list" 주소로 해당 memberId의 리스트 조회 기능 구현
